### PR TITLE
packaging: add initial SELinux policy and RPM hooks for smoo-gadget

### DIFF
--- a/packaging/selinux/smoo_gadget.fc
+++ b/packaging/selinux/smoo_gadget.fc
@@ -1,0 +1,1 @@
+/usr/bin/smoo-gadget    --      gen_context(system_u:object_r:smoo_gadget_exec_t,s0)

--- a/packaging/selinux/smoo_gadget.te
+++ b/packaging/selinux/smoo_gadget.te
@@ -1,0 +1,34 @@
+policy_module(smoo_gadget, 1.0)
+
+require {
+    type configfs_t;
+    type functionfs_t;
+    type ublk_control_t;
+    type ublk_device_t;
+
+    class capability { dac_override net_bind_service setgid setuid sys_admin sys_resource };
+    class chr_file { getattr ioctl lock map open read write };
+    class dir { add_name create getattr open read remove_name search write };
+    class file { create getattr map open read rename setattr unlink write };
+    class filesystem getattr;
+    class sock_file write;
+}
+
+type smoo_gadget_t;
+type smoo_gadget_exec_t;
+
+init_daemon_domain(smoo_gadget_t, smoo_gadget_exec_t)
+
+allow smoo_gadget_t self:capability { dac_override net_bind_service setgid setuid sys_admin sys_resource };
+allow smoo_gadget_t self:filesystem getattr;
+allow smoo_gadget_t self:sock_file write;
+
+allow smoo_gadget_t configfs_t:dir { add_name create getattr open read remove_name search write };
+allow smoo_gadget_t configfs_t:file { create getattr map open read rename setattr unlink write };
+
+allow smoo_gadget_t functionfs_t:dir { add_name create getattr open read remove_name search write };
+allow smoo_gadget_t functionfs_t:file { create getattr map open read rename setattr unlink write };
+allow smoo_gadget_t functionfs_t:chr_file { getattr ioctl lock map open read write };
+
+allow smoo_gadget_t ublk_control_t:chr_file { getattr ioctl lock map open read write };
+allow smoo_gadget_t ublk_device_t:chr_file { getattr ioctl lock map open read write };


### PR DESCRIPTION
### Motivation
- SELinux denials during early boot/switchroot prevent `smoo-gadget` from initializing, so provide a minimal, scoped policy to unblock boot and enable iteration from AVC logs.

### Description
- Add `packaging/selinux/smoo_gadget.te` which defines `smoo_gadget_t`/`smoo_gadget_exec_t` and allows the current FunctionFS/configfs/ublk interactions the gadget needs. 
- Add `packaging/selinux/smoo_gadget.fc` to label `/usr/bin/smoo-gadget` so it transitions into the new domain at exec time. 
- Update `smoo.spec` to add SELinux build/runtime deps (`checkpolicy`, `selinux-policy-devel`, `policycoreutils`), build the module (`smoo_gadget.pp`) during `%build`, install the `.pp` into the gadget subpackage, and automatically install/remove the module in `%post gadget` / `%postun gadget` using `semodule`.

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded. 
- Ran `cargo check --workspace --locked` and it completed successfully. 
- Ran `cargo clippy --workspace` and it completed successfully. 
- Attempted to expand the spec with `rpmspec -P smoo.spec`, but `rpmspec` is not available in this environment so that validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c5456b0483259889bf39df55274e)