### PR TITLE
feat(gadget): support user recovery handover

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ sudo ./target/debug/smoo-host --file random.img
 
 ## Status
 
-This is an early prototype. It requires a recent Linux kernel with [FunctionFS][ffs], and [ublk][] support enabled. It
-should work on any device with a UDC, and is tested primarily on SDM670/SDM845 pocket computers.
+This is an early prototype. The gadget side requires Linux 6.16 or newer with [FunctionFS][ffs], and [ublk][] support
+enabled.
+
+It should work on any device with a UDC, and is tested primarily on SDM670/SDM845 pocket computers.
 
 ## Development
 

--- a/crates/smoo-gadget-app/src/lib.rs
+++ b/crates/smoo-gadget-app/src/lib.rs
@@ -97,6 +97,9 @@ pub struct Args {
     /// Adopt existing ublk devices via user recovery.
     #[arg(long)]
     pub adopt: bool,
+    /// Maximum time to wait for the previous owner during --adopt.
+    #[arg(long, value_name = "TIMEOUT", value_parser = parse_duration)]
+    pub adopt_deadline: Option<Duration>,
     /// Expose Prometheus metrics on this TCP port (0 disables).
     #[arg(long, default_value_t = 0)]
     pub metrics_port: u16,
@@ -137,6 +140,7 @@ impl Default for Args {
             dma_heap: DmaHeapSelection::System,
             state_file: None,
             adopt: false,
+            adopt_deadline: None,
             metrics_port: 0,
             ffs_dir: None,
             mimic_fastboot: false,
@@ -158,17 +162,35 @@ pub async fn run_with_args(args: Args) -> Result<()> {
 }
 
 async fn run_impl(args: Args) -> Result<()> {
+    ensure!(
+        !args.adopt || args.state_file.is_some(),
+        "--adopt requires --state-file"
+    );
+    ensure!(
+        args.adopt || args.adopt_deadline.is_none(),
+        "--adopt-deadline requires --adopt"
+    );
     let metrics_shutdown = CancellationToken::new();
     let metrics_task = spawn_metrics_listener(args.metrics_port, metrics_shutdown.clone())?;
     let mut ublk = SmooUblk::new().context("init ublk")?;
     let mut state_store = if let Some(path) = args.state_file.as_ref() {
         info!(path = ?path, "state file configured");
-        match StateStore::load(path.clone()) {
-            Ok(store) => store,
-            Err(err) => {
-                warn!(path = ?path, error = ?err, "failed to load state file; starting new session");
-                StateStore::new_with_path(path.clone())
+        let exists = path
+            .try_exists()
+            .with_context(|| format!("check state file {}", path.display()))?;
+        if exists && !args.adopt {
+            anyhow::bail!(
+                "state file {} already exists; pass --adopt to recover it or remove it before starting a new session",
+                path.display()
+            );
+        }
+        if exists {
+            StateStore::load(path.clone()).context("load state file")?
+        } else {
+            if args.adopt {
+                warn!(path = ?path, "--adopt requested but state file does not exist; starting empty session");
             }
+            StateStore::new_with_path(path.clone())
         }
     } else {
         debug!("state file disabled; crash recovery off");
@@ -177,7 +199,7 @@ async fn run_impl(args: Args) -> Result<()> {
 
     initialize_session(&mut ublk, &mut state_store).await?;
     if args.adopt {
-        adopt_prepare(&mut ublk, &mut state_store).await?;
+        adopt_prepare(&mut ublk, &mut state_store, args.adopt_deadline).await?;
     }
 
     let (custom, endpoints, _gadget_guard, _ffs_dir) =
@@ -674,12 +696,21 @@ async fn drain_queue_batch(
     outstanding: &mut HashMap<u32, HashMap<(u16, u16), OutstandingRequest>>,
     data_plane_tx: &mpsc::UnboundedSender<DataPlaneEvent>,
     queue_rx: &mut mpsc::Receiver<QueueEvent>,
+    expected_queue_abort: bool,
 ) -> Result<()> {
     let mut processed = 0;
     while processed < QUEUE_BATCH_MAX.saturating_sub(1) {
         match queue_rx.try_recv() {
             Ok(evt) => {
-                handle_queue_event(runtime, link, outstanding, data_plane_tx, evt).await?;
+                handle_queue_event(
+                    runtime,
+                    link,
+                    outstanding,
+                    data_plane_tx,
+                    evt,
+                    expected_queue_abort,
+                )
+                .await?;
                 processed += 1;
             }
             Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
@@ -935,6 +966,12 @@ enum ShutdownAction {
     ForceNow,
 }
 
+struct HandoverState {
+    dev_ids: Vec<u32>,
+    quiesce_task: Option<std::thread::JoinHandle<Result<()>>>,
+    quiesce_complete: bool,
+}
+
 fn advance_shutdown_state(
     signal_name: &str,
     shutdown_state: &mut ShutdownState,
@@ -1019,6 +1056,7 @@ async fn run_event_loop(
     let mut exit_reason: Option<String> = None;
     let mut recovery_exit = false;
     let mut shutdown_state = ShutdownState::Running;
+    let mut handover: Option<HandoverState> = None;
     let mut last_status_seq = ep0_signals.status_seq();
     let mut last_lifecycle_seq = ep0_signals.lifecycle_seq();
 
@@ -1056,6 +1094,61 @@ async fn run_event_loop(
             );
         }
 
+        if let Some(handover_state) = handover.as_mut() {
+            if handover_state.quiesce_task.is_none()
+                && !handover_state.quiesce_complete
+                && runtime.inflight_io == 0
+            {
+                info!("handover in-flight IO drained; quiescing ublk devices");
+                handover_state.quiesce_task = Some(
+                    ublk.spawn_quiesce_devices(handover_state.dev_ids.clone(), Duration::ZERO)
+                        .context("spawn handover quiesce")?,
+                );
+            }
+
+            if handover_state
+                .quiesce_task
+                .as_ref()
+                .is_some_and(|task| task.is_finished())
+            {
+                let quiesce_task = handover_state
+                    .quiesce_task
+                    .take()
+                    .expect("handover quiesce task missing");
+                match quiesce_task.join() {
+                    Ok(Ok(())) => {
+                        handover_state.quiesce_complete = true;
+                        info!("handover quiesce complete");
+                    }
+                    Ok(Err(err)) => {
+                        warn!(error = ?err, "handover quiesce failed");
+                        note_exit_reason(
+                            &mut exit_reason,
+                            format!("handover quiesce failed: {err:#}"),
+                        );
+                        io_error = Some(err);
+                        break;
+                    }
+                    Err(err) => {
+                        let err = anyhow!("handover quiesce thread panicked: {err:?}");
+                        warn!(error = ?err, "handover quiesce panicked");
+                        note_exit_reason(&mut exit_reason, err.to_string());
+                        io_error = Some(err);
+                        break;
+                    }
+                }
+            }
+
+            if handover_state.quiesce_complete && runtime.inflight_io == 0 {
+                note_exit_reason(&mut exit_reason, "handover in-flight IO drained");
+                info!("handover in-flight IO drained; releasing ublk devices for adoption");
+                let _ = control_stop.send(true);
+                release_devices_for_user_recovery(&mut runtime, &mut queue_tx).await?;
+                recovery_exit = true;
+                break;
+            }
+        }
+
         if let ShutdownState::Graceful { deadline } = shutdown_state {
             if Instant::now() >= deadline {
                 warn!("graceful shutdown timed out; forcing shutdown");
@@ -1091,13 +1184,11 @@ async fn run_event_loop(
                     ShutdownAction::ForceNow => break,
                 }
             }
-            Some(_) = hup.recv() => {
-                info!("SIGHUP received; initiating user recovery");
-                note_exit_reason(&mut exit_reason, "SIGHUP received; entering user recovery");
-                let _ = control_stop.send(true);
-                begin_user_recovery(ublk, &mut runtime).await?;
-                recovery_exit = true;
-                break;
+            Some(_) = hup.recv(), if handover.is_none() => {
+                info!("SIGHUP received; preparing user-recovery handover");
+                note_exit_reason(&mut exit_reason, "SIGHUP received; preparing user-recovery handover");
+                handover = Some(begin_user_recovery_handover(ublk, &runtime)?);
+                stop_accepting_new_io(&mut runtime, &mut queue_tx).await;
             }
             event = data_plane_rx.recv() => {
                 if let Some(event) = event {
@@ -1119,7 +1210,7 @@ async fn run_event_loop(
                     }
                 }
             }
-            Some(config) = control_rx.recv(), if matches!(shutdown_state, ShutdownState::Running) => {
+            Some(config) = control_rx.recv(), if matches!(shutdown_state, ShutdownState::Running) && handover.is_none() => {
                 if let Err(err) = handle_config_message(
                     ublk,
                     &mut runtime,
@@ -1135,7 +1226,7 @@ async fn run_event_loop(
             _ = ep0_notified.as_mut() => {
                 continue;
             }
-            maybe_evt = queue_rx.recv(), if !matches!(shutdown_state, ShutdownState::Forceful) && runtime.io_pump.is_some() => {
+            maybe_evt = queue_rx.recv(), if handover.is_none() && !matches!(shutdown_state, ShutdownState::Forceful) && runtime.io_pump.is_some() => {
                 if let Some(evt) = maybe_evt {
                     if let Err(err) = handle_queue_event(
                         &mut runtime,
@@ -1143,6 +1234,7 @@ async fn run_event_loop(
                         &mut outstanding,
                         &data_plane_tx,
                         evt,
+                        handover.is_some(),
                     )
                     .await
                     {
@@ -1160,6 +1252,7 @@ async fn run_event_loop(
                         &mut outstanding,
                         &data_plane_tx,
                         &mut queue_rx,
+                        handover.is_some(),
                     )
                     .await
                     {
@@ -1190,40 +1283,44 @@ async fn run_event_loop(
                 }
             }
             _ = liveness_tick.tick() => {
-                if let Err(err) = drive_runtime(
-                    ublk,
-                    &mut runtime,
-                    &mut link,
-                    &mut outstanding,
-                    queue_tx.as_ref(),
-                    false,
-                ).await {
-                    warn!(error = ?err, "run_event_loop: drive_runtime failed on liveness tick");
-                    note_exit_reason(
-                        &mut exit_reason,
-                        format!("drive_runtime on liveness tick failed: {err:#}"),
-                    );
-                    io_error = Some(err);
-                    break;
+                if handover.is_none() {
+                    if let Err(err) = drive_runtime(
+                        ublk,
+                        &mut runtime,
+                        &mut link,
+                        &mut outstanding,
+                        queue_tx.as_ref(),
+                        false,
+                    ).await {
+                        warn!(error = ?err, "run_event_loop: drive_runtime failed on liveness tick");
+                        note_exit_reason(
+                            &mut exit_reason,
+                            format!("drive_runtime on liveness tick failed: {err:#}"),
+                        );
+                        io_error = Some(err);
+                        break;
+                    }
                 }
             }
             _ = &mut idle_sleep => {
-                let allow_reconcile = matches!(shutdown_state, ShutdownState::Running);
-                if let Err(err) = drive_runtime(
-                    ublk,
-                    &mut runtime,
-                    &mut link,
-                    &mut outstanding,
-                    queue_tx.as_ref(),
-                    allow_reconcile,
-                ).await {
-                    warn!(error = ?err, "run_event_loop: drive_runtime failed on idle maintenance");
-                    note_exit_reason(
-                        &mut exit_reason,
-                        format!("drive_runtime on idle maintenance failed: {err:#}"),
-                    );
-                    io_error = Some(err);
-                    break;
+                if handover.is_none() {
+                    let allow_reconcile = matches!(shutdown_state, ShutdownState::Running);
+                    if let Err(err) = drive_runtime(
+                        ublk,
+                        &mut runtime,
+                        &mut link,
+                        &mut outstanding,
+                        queue_tx.as_ref(),
+                        allow_reconcile,
+                    ).await {
+                        warn!(error = ?err, "run_event_loop: drive_runtime failed on idle maintenance");
+                        note_exit_reason(
+                            &mut exit_reason,
+                            format!("drive_runtime on idle maintenance failed: {err:#}"),
+                        );
+                        io_error = Some(err);
+                        break;
+                    }
                 }
             }
         }
@@ -1660,7 +1757,11 @@ async fn initialize_session(_ublk: &mut SmooUblk, state_store: &mut StateStore) 
     Ok(())
 }
 
-async fn adopt_prepare(ublk: &mut SmooUblk, state_store: &mut StateStore) -> Result<()> {
+async fn adopt_prepare(
+    ublk: &mut SmooUblk,
+    state_store: &mut StateStore,
+    deadline: Option<Duration>,
+) -> Result<()> {
     let mut dev_ids = Vec::new();
     let mut owner_pids = HashSet::new();
     let mut stale_devices = false;
@@ -1715,43 +1816,53 @@ async fn adopt_prepare(ublk: &mut SmooUblk, state_store: &mut StateStore) -> Res
             libc::kill(pid, libc::SIGHUP);
         }
         info!(pid, "waiting for prior owner to exit before adopting");
-        wait_for_owner_exit(ublk, &dev_ids, pid, Duration::from_secs(3)).await?;
+        wait_for_user_recovery_start(ublk, &dev_ids, pid, deadline).await?;
     }
 
     Ok(())
 }
 
-async fn wait_for_owner_exit(
+async fn wait_for_user_recovery_start(
     ublk: &mut SmooUblk,
     dev_ids: &[u32],
     target_pid: i32,
-    timeout: Duration,
+    timeout: Option<Duration>,
 ) -> Result<()> {
-    let deadline = Instant::now() + timeout;
+    let deadline = timeout.map(|timeout| Instant::now() + timeout);
+    let mut remaining: HashSet<u32> = dev_ids.iter().copied().collect();
     loop {
-        let mut still_owned = false;
-        for dev_id in dev_ids {
-            match ublk.owner_pid(*dev_id).await {
-                Ok(pid) => {
-                    debug!(dev_id, pid, target_pid, "owner check during adopt wait");
-                    if pid == target_pid {
-                        still_owned = true;
-                    } else if pid > 0 && pid != target_pid {
-                        anyhow::bail!(
-                            "device {dev_id} now owned by unexpected pid {pid} during adopt"
-                        );
-                    }
+        for dev_id in dev_ids.iter().copied() {
+            if !remaining.contains(&dev_id) {
+                continue;
+            }
+            match ublk.start_user_recovery(dev_id).await {
+                Ok(()) => {
+                    remaining.remove(&dev_id);
+                    debug!(dev_id, target_pid, "device entered user recovery");
+                }
+                Err(err) if error_is_errno(&err, libc::EBUSY) => {
+                    debug!(dev_id, target_pid, "device not ready for user recovery yet");
                 }
                 Err(err) => {
-                    warn!(dev_id, error = ?err, "owner pid query failed during adopt wait");
+                    return Err(err).with_context(|| {
+                        format!("start user recovery for device {dev_id} during adopt")
+                    });
                 }
             }
         }
-        if !still_owned {
+        if remaining.is_empty() {
             return Ok(());
         }
-        if Instant::now() >= deadline {
-            anyhow::bail!("owner pid {target_pid} still active after adopt wait");
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            warn!(
+                target_pid,
+                remaining_dev_ids = ?remaining,
+                "adopt deadline elapsed; sending SIGINT to prior owner"
+            );
+            unsafe {
+                libc::kill(target_pid, libc::SIGINT);
+            }
+            anyhow::bail!("owner pid {target_pid} still active after adopt deadline");
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -2038,23 +2149,46 @@ async fn force_remove_with_retry(ublk: &mut SmooUblk, dev_id: u32) -> Result<()>
     Ok(())
 }
 
-async fn begin_user_recovery(ublk: &mut SmooUblk, runtime: &mut RuntimeState) -> Result<()> {
-    ublk.preserve_devices_on_drop();
-    for (_, tasks) in runtime.queue_tasks.drain() {
-        tasks.shutdown().await;
-    }
+fn begin_user_recovery_handover(
+    ublk: &mut SmooUblk,
+    runtime: &RuntimeState,
+) -> Result<HandoverState> {
+    ensure!(
+        runtime.state_store.path().is_some(),
+        "SIGHUP handover requires --state-file"
+    );
     let mut dev_ids = Vec::new();
-    for ctrl in runtime.exports.values_mut() {
-        if let Some((ctrl, queues)) = ctrl.take_device_handles() {
-            dev_ids.push(ctrl.dev_id());
-            drop(SmooUblkDevice::from_parts(ctrl, queues));
-        } else if let Some(dev_id) = ctrl.dev_id() {
-            dev_ids.push(dev_id);
+    for controller in runtime.exports.values() {
+        if let Some(dev_id) = controller.dev_id() {
+            if !dev_ids.contains(&dev_id) {
+                dev_ids.push(dev_id);
+            }
         }
     }
-    for dev_id in dev_ids {
-        if let Err(err) = ublk.start_user_recovery(dev_id).await {
-            warn!(dev_id, error = ?err, "start user recovery failed");
+    ensure!(
+        !dev_ids.is_empty(),
+        "SIGHUP handover requested but no ublk devices are active"
+    );
+    ublk.preserve_devices_on_drop();
+    Ok(HandoverState {
+        dev_ids,
+        quiesce_task: None,
+        quiesce_complete: false,
+    })
+}
+
+async fn release_devices_for_user_recovery(
+    runtime: &mut RuntimeState,
+    queue_tx: &mut Option<QueueSender>,
+) -> Result<()> {
+    stop_accepting_new_io(runtime, queue_tx).await;
+    for controller in runtime.exports.values_mut() {
+        if let Some((ctrl, queues)) = controller.take_device_handles() {
+            let dev_id = ctrl.dev_id();
+            info!(dev_id, "releasing ublk device for user recovery");
+            drop(SmooUblkDevice::from_parts(ctrl, queues));
+        } else if let Some(dev_id) = controller.dev_id() {
+            info!(dev_id, "leaving ublk device for user recovery");
         }
     }
     Ok(())
@@ -2177,6 +2311,7 @@ async fn handle_queue_event(
     outstanding: &mut HashMap<u32, HashMap<(u16, u16), OutstandingRequest>>,
     data_plane_tx: &mpsc::UnboundedSender<DataPlaneEvent>,
     event: QueueEvent,
+    expected_queue_abort: bool,
 ) -> Result<()> {
     match event {
         QueueEvent::Request {
@@ -2254,6 +2389,13 @@ async fn handle_queue_event(
             dev_id,
             error,
         } => {
+            if expected_queue_abort && error_is_errno(&error, libc::ENODEV) {
+                info!(
+                    export_id,
+                    dev_id, "queue fetch aborted during handover quiesce"
+                );
+                return Ok(());
+            }
             warn!(
                 export_id,
                 dev_id,
@@ -2393,6 +2535,40 @@ fn parse_byte_size(input: &str) -> Result<usize, String> {
         .ok_or_else(|| "byte size overflows usize".to_string())
 }
 
+fn parse_duration(input: &str) -> Result<Duration, String> {
+    let input = input.trim();
+    let digits = input
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(input.len());
+    if digits == 0 {
+        return Err("duration must start with a number".to_string());
+    }
+
+    let value = input[..digits]
+        .parse::<u64>()
+        .map_err(|err| err.to_string())?;
+    if value == 0 {
+        return Err("duration must be non-zero".to_string());
+    }
+
+    let suffix = input[digits..].trim().to_ascii_lowercase();
+    match suffix.as_str() {
+        "ms" => Ok(Duration::from_millis(value)),
+        "" | "s" => Ok(Duration::from_secs(value)),
+        "m" => value
+            .checked_mul(60)
+            .map(Duration::from_secs)
+            .ok_or_else(|| "duration overflows u64 seconds".to_string()),
+        "h" => value
+            .checked_mul(60 * 60)
+            .map(Duration::from_secs)
+            .ok_or_else(|| "duration overflows u64 seconds".to_string()),
+        _ => Err(format!(
+            "unsupported duration suffix {suffix:?}; use ms, s, m, or h"
+        )),
+    }
+}
+
 fn validate_persisted_record(record: &PersistedExportRecord) -> Result<()> {
     ensure!(
         record.export_id != 0,
@@ -2469,7 +2645,8 @@ fn build_spec_from_export(export: ConfigExport) -> Result<ExportSpec> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_byte_size;
+    use super::{parse_byte_size, parse_duration};
+    use std::time::Duration;
 
     #[test]
     fn parse_byte_size_accepts_raw_bytes() {
@@ -2489,5 +2666,21 @@ mod tests {
         assert!(parse_byte_size("0").is_err());
         assert!(parse_byte_size("MiB").is_err());
         assert!(parse_byte_size("1TiB").is_err());
+    }
+
+    #[test]
+    fn parse_duration_accepts_supported_suffixes() {
+        assert_eq!(parse_duration("5").unwrap(), Duration::from_secs(5));
+        assert_eq!(parse_duration("250ms").unwrap(), Duration::from_millis(250));
+        assert_eq!(parse_duration("2s").unwrap(), Duration::from_secs(2));
+        assert_eq!(parse_duration("3m").unwrap(), Duration::from_secs(180));
+        assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn parse_duration_rejects_invalid_values() {
+        assert!(parse_duration("0").is_err());
+        assert!(parse_duration("ms").is_err());
+        assert!(parse_duration("1d").is_err());
     }
 }

--- a/crates/smoo-gadget-ublk/build.rs
+++ b/crates/smoo-gadget-ublk/build.rs
@@ -17,6 +17,14 @@ fn add_serialize(outdir: &std::path::Path) -> anyhow::Result<i32> {
         "use serde::{{Serialize, Deserialize}};\n{}",
         regex::Regex::new(r"#\s*\[\s*derive\s*\((?P<d>[^)]+)\)\s*\]\s*pub\s*(?P<s>struct|enum)")?
             .replace_all(&res, "#[derive($d, Serialize, Deserialize)] pub $s")
+    )
+    .replace(
+        "#[derive(Copy, Clone, Serialize, Deserialize)] pub struct ublksrv_io_desc",
+        "#[derive(Copy, Clone)] pub struct ublksrv_io_desc",
+    )
+    .replace(
+        "#[derive(Copy, Clone, Serialize, Deserialize)] pub struct ublksrv_io_cmd",
+        "#[derive(Copy, Clone)] pub struct ublksrv_io_cmd",
     );
     let mut fd = File::create(outdir.join("ublk_cmd.rs"))?;
     fd.write_all(data.as_bytes())?;
@@ -35,6 +43,8 @@ fn main() {
 #include "ublk_cmd.h"
 
 #ifdef UBLK_F_CMD_IOCTL_ENCODE
+// Bindgen does not emit constants for Linux _IO*() function-like macros.
+// Force them through C consts, then strip this prefix in ParseCallbacks.
 #define MARK_FIX_753(req_name) const unsigned int Fix753_##req_name = req_name;
 #else
 #define MARK_FIX_753(req_name)
@@ -55,6 +65,9 @@ MARK_FIX_753(UBLK_U_IO_FETCH_REQ);
 MARK_FIX_753(UBLK_U_IO_COMMIT_AND_FETCH_REQ);
 MARK_FIX_753(UBLK_U_IO_NEED_GET_DATA);
 MARK_FIX_753(UBLK_U_CMD_DEL_DEV_ASYNC);
+#ifdef UBLK_U_CMD_QUIESCE_DEV
+MARK_FIX_753(UBLK_U_CMD_QUIESCE_DEV);
+#endif
 MARK_FIX_753(UBLK_U_IO_REGISTER_IO_BUF);
 MARK_FIX_753(UBLK_U_IO_UNREGISTER_IO_BUF);
 const int Fix753_UBLK_IO_RES_ABORT = UBLK_IO_RES_ABORT;

--- a/crates/smoo-gadget-ublk/src/lib.rs
+++ b/crates/smoo-gadget-ublk/src/lib.rs
@@ -5,11 +5,11 @@ use crate::buffers::{BufferGuard, QueueBuffers};
 use crate::sys::{
     UBLK_CMD_ADD_DEV, UBLK_CMD_DEL_DEV, UBLK_CMD_END_USER_RECOVERY, UBLK_CMD_GET_DEV_INFO,
     UBLK_CMD_GET_DEV_INFO2, UBLK_CMD_GET_PARAMS, UBLK_CMD_SET_PARAMS, UBLK_CMD_START_DEV,
-    UBLK_CMD_START_USER_RECOVERY, UBLK_CMD_STOP_DEV, UBLK_F_USER_RECOVERY,
+    UBLK_CMD_START_USER_RECOVERY, UBLK_CMD_STOP_DEV, UBLK_F_QUIESCE, UBLK_F_USER_RECOVERY,
     UBLK_F_USER_RECOVERY_REISSUE, UBLK_IO_OP_DISCARD, UBLK_IO_OP_FLUSH, UBLK_IO_OP_READ,
-    UBLK_IO_OP_WRITE, UBLK_PARAM_TYPE_BASIC, UBLK_U_IO_COMMIT_AND_FETCH_REQ, UBLK_U_IO_FETCH_REQ,
-    ublk_param_basic, ublk_params, ublksrv_ctrl_cmd, ublksrv_ctrl_dev_info, ublksrv_io_cmd,
-    ublksrv_io_desc,
+    UBLK_IO_OP_WRITE, UBLK_IO_RES_ABORT, UBLK_PARAM_TYPE_BASIC, UBLK_U_CMD_QUIESCE_DEV,
+    UBLK_U_IO_COMMIT_AND_FETCH_REQ, UBLK_U_IO_FETCH_REQ, ublk_param_basic, ublk_params,
+    ublksrv_ctrl_cmd, ublksrv_ctrl_dev_info, ublksrv_io_cmd, ublksrv_io_desc,
 };
 use anyhow::{Context, anyhow, ensure};
 use async_channel::{Receiver, RecvError, Sender};
@@ -301,6 +301,13 @@ async fn submit_ctrl_command_threaded(
     .await
 }
 
+fn quiesce_timeout_ms(timeout: Duration) -> anyhow::Result<u64> {
+    if timeout.is_zero() {
+        return Ok(0);
+    }
+    u64::try_from(timeout.as_millis()).context("quiesce timeout exceeds u64 milliseconds")
+}
+
 pub type UblkBuffer<'a> = BufferGuard<'a>;
 
 impl SmooUblk {
@@ -316,6 +323,42 @@ impl SmooUblk {
     pub async fn owner_pid(&self, dev_id: u32) -> anyhow::Result<i32> {
         let info = self.get_device_info(dev_id).await?;
         Ok(info.ublksrv_pid)
+    }
+
+    /// Start a blocking quiesce sequence on a helper thread.
+    ///
+    /// `timeout == Duration::ZERO` maps to the kernel's "wait forever" mode,
+    /// which is what graceful server handover needs while the async app loop
+    /// continues servicing in-flight I/O.
+    pub fn spawn_quiesce_devices(
+        &self,
+        dev_ids: Vec<u32>,
+        timeout: Duration,
+    ) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
+        let sender = self.sender.clone();
+        let timeout_ms = quiesce_timeout_ms(timeout)?;
+        thread::Builder::new()
+            .name("smoo-gadget-ublk-quiesce".to_string())
+            .spawn(move || {
+                for dev_id in dev_ids {
+                    let mut cmd = ublksrv_ctrl_cmd {
+                        dev_id,
+                        queue_id: u16::MAX,
+                        ..Default::default()
+                    };
+                    cmd.data[0] = timeout_ms;
+                    info!(dev_id, timeout_ms, "issuing UBLK_CMD_QUIESCE_DEV");
+                    submit_ctrl_command_blocking(
+                        &sender,
+                        UBLK_U_CMD_QUIESCE_DEV,
+                        cmd,
+                        "quiesce device",
+                        None,
+                    )?;
+                }
+                Ok(())
+            })
+            .context("spawn ublk quiesce thread")
     }
 
     pub fn new() -> anyhow::Result<Self> {
@@ -567,7 +610,8 @@ impl SmooUblk {
                 ublksrv_pid: unsafe { libc::getpid() } as i32,
                 ..Default::default()
             };
-            info.flags |= (UBLK_F_USER_RECOVERY | UBLK_F_USER_RECOVERY_REISSUE) as u64;
+            info.flags |=
+                (UBLK_F_USER_RECOVERY | UBLK_F_USER_RECOVERY_REISSUE | UBLK_F_QUIESCE) as u64;
 
             // ublk_params is passed in ublksrv_ctrl_dev_info during UBLK_CMD_SET_PARAMS
             let mut params = ublk_params {
@@ -1352,6 +1396,7 @@ impl UblkQueueRuntime {
         let req = receiver
             .recv()
             .await
+            .map_err(|_| io::Error::from_raw_os_error(libc::ENODEV))
             .context("smoo-gadget-ublk device channel closed")?;
         trace!(
             dev_id = req.dev_id,
@@ -1511,9 +1556,35 @@ fn queue_worker_main(cfg: QueueWorkerConfig) -> anyhow::Result<()> {
 
     let timeout = types::Timespec::from(Duration::from_millis(5));
     let submit_args = types::SubmitArgs::new().timespec(&timeout);
+    // Quiesce aborts idle FETCH commands, but already-fetched requests still
+    // need their completions committed before the old owner can exit cleanly.
+    let mut tag_active = vec![false; queue_depth as usize];
+    let mut tag_open = vec![true; queue_depth as usize];
+    let mut open_tags = queue_depth as usize;
 
-    while !stop.load(Ordering::SeqCst) {
+    while !stop.load(Ordering::SeqCst) && (open_tags > 0 || tag_active.iter().any(|active| *active))
+    {
         while let Ok(comp) = completion_rx.try_recv() {
+            let tag_index = comp.tag as usize;
+            if tag_index >= tag_open.len() {
+                warn!(
+                    dev_id = dev_id,
+                    queue_id = queue_id,
+                    tag = comp.tag,
+                    "dropping completion for invalid ublk tag"
+                );
+                continue;
+            }
+            if !tag_open[tag_index] {
+                debug!(
+                    dev_id = dev_id,
+                    queue_id = queue_id,
+                    tag = comp.tag,
+                    "dropping completion for aborted ublk tag"
+                );
+                continue;
+            }
+            tag_active[tag_index] = false;
             let cmd_addr = buf_ptrs[comp.tag as usize];
             trace!(
                 dev_id = dev_id,
@@ -1550,17 +1621,69 @@ fn queue_worker_main(cfg: QueueWorkerConfig) -> anyhow::Result<()> {
         }
 
         while let Some(cqe) = ring.completion().next() {
+            let tag = cqe.user_data() as u16;
+            let tag_index = tag as usize;
             let result = cqe.result();
             if result < 0 {
+                if result == UBLK_IO_RES_ABORT {
+                    let active = tag_active.get(tag_index).copied().unwrap_or(false);
+                    if active {
+                        debug!(
+                            dev = dev_id,
+                            queue = queue_id,
+                            tag,
+                            open_tags,
+                            "active queue tag aborted by ublk; awaiting completion or release"
+                        );
+                        continue;
+                    }
+                    if let Some(open) = tag_open.get_mut(tag_index) {
+                        if *open {
+                            *open = false;
+                            open_tags = open_tags.saturating_sub(1);
+                        }
+                    }
+                    debug!(
+                        dev = dev_id,
+                        queue = queue_id,
+                        tag,
+                        active,
+                        open_tags,
+                        "queue fetch aborted by ublk"
+                    );
+                    if open_tags == 0 && !tag_active.iter().any(|active| *active) {
+                        return Ok(());
+                    }
+                    continue;
+                }
                 warn!(
                     dev = dev_id,
                     queue = queue_id,
+                    tag,
                     "queue cqe error: {}",
                     result
                 );
                 return Err(io::Error::from_raw_os_error(-result).into());
             }
-            let tag = cqe.user_data() as u16;
+            if tag_index >= tag_open.len() {
+                warn!(
+                    dev_id = dev_id,
+                    queue_id = queue_id,
+                    tag,
+                    "queue cqe used invalid tag"
+                );
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid ublk tag").into());
+            }
+            if !tag_open[tag_index] {
+                debug!(
+                    dev_id = dev_id,
+                    queue_id = queue_id,
+                    tag,
+                    "ignoring request for aborted ublk tag"
+                );
+                continue;
+            }
+            tag_active[tag_index] = true;
             let desc = unsafe { ptr::read(iod_base.add(tag as usize)) };
             let request = UblkIoRequest {
                 dev_id,
@@ -1568,7 +1691,7 @@ fn queue_worker_main(cfg: QueueWorkerConfig) -> anyhow::Result<()> {
                 tag,
                 op: decode_op(desc.op_flags),
                 sector: desc.start_sector,
-                num_sectors: desc.nr_sectors,
+                num_sectors: io_desc_nr_sectors(&desc),
             };
             trace!(
                 dev_id = dev_id,
@@ -1612,12 +1735,7 @@ fn queue_cmd(
         fd,
         ioctl_encode,
     } = ctx;
-    let io_cmd = ublksrv_io_cmd {
-        q_id: queue_id,
-        tag,
-        result,
-        addr: desc_addr,
-    };
+    let io_cmd = io_cmd_with_addr(queue_id, tag, result, desc_addr);
     trace!(
         queue_id = queue_id,
         tag = tag,
@@ -1684,6 +1802,21 @@ fn queue_cmd_buf_size(depth: u32) -> usize {
         return page_sz;
     }
     desc_bytes.div_ceil(page_sz) * page_sz
+}
+
+fn io_desc_nr_sectors(desc: &ublksrv_io_desc) -> u32 {
+    // Linux exposes nr_sectors/nr_zones as an anonymous C union.
+    unsafe { desc.__bindgen_anon_1.nr_sectors }
+}
+
+fn io_cmd_with_addr(q_id: u16, tag: u16, result: i32, addr: u64) -> ublksrv_io_cmd {
+    // Linux exposes addr/zone_append_lba as an anonymous C union.
+    ublksrv_io_cmd {
+        q_id,
+        tag,
+        result,
+        __bindgen_anon_1: sys::ublksrv_io_cmd__bindgen_ty_1 { addr },
+    }
 }
 
 fn encode_cmd_op(cmd: u32, ioctl_encode: bool) -> u32 {

--- a/crates/smoo-gadget-ublk/ublk_cmd.h
+++ b/crates/smoo-gadget-ublk/ublk_cmd.h
@@ -51,6 +51,10 @@
 	_IOR('u', 0x13, struct ublksrv_ctrl_cmd)
 #define UBLK_U_CMD_DEL_DEV_ASYNC	\
 	_IOR('u', 0x14, struct ublksrv_ctrl_cmd)
+#define UBLK_U_CMD_UPDATE_SIZE		\
+	_IOWR('u', 0x15, struct ublksrv_ctrl_cmd)
+#define UBLK_U_CMD_QUIESCE_DEV		\
+	_IOWR('u', 0x16, struct ublksrv_ctrl_cmd)
 
 /*
  * 64bits are enough now, and it should be easy to extend in case of
@@ -171,8 +175,18 @@
  */
 #define UBLK_F_NEED_GET_DATA (1UL << 2)
 
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is met with errors
+ * - I/O issued while there is no ublk server queues
+ */
 #define UBLK_F_USER_RECOVERY	(1UL << 3)
 
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is reissued
+ * - I/O issued while there is no ublk server queues
+ */
 #define UBLK_F_USER_RECOVERY_REISSUE	(1UL << 4)
 
 /*
@@ -199,7 +213,13 @@
 /* use ioctl encoding for uring command */
 #define UBLK_F_CMD_IOCTL_ENCODE	(1UL << 6)
 
-/* Copy between request and user buffer by pread()/pwrite() */
+/*
+ *  Copy between request and user buffer by pread()/pwrite()
+ *
+ *  Not available for UBLK_F_UNPRIVILEGED_DEV, otherwise userspace may
+ *  deceive us by not filling request buffer, then kernel uninitialized
+ *  data may be leaked.
+ */
 #define UBLK_F_USER_COPY	(1UL << 7)
 
 /*
@@ -207,6 +227,19 @@
  * deny the request by returning an error.
  */
 #define UBLK_F_ZONED (1ULL << 8)
+
+/*
+ * - Block devices are recoverable if ublk server exits and restarts
+ * - Outstanding I/O when ublk server exits is met with errors
+ * - I/O issued while there is no ublk server is met with errors
+ */
+#define UBLK_F_USER_RECOVERY_FAIL_IO (1ULL << 9)
+
+/*
+ * Resizing a block device is possible with UBLK_U_CMD_UPDATE_SIZE
+ * New size is passed in cmd->data[0] and is in units of sectors
+ */
+#define UBLK_F_UPDATE_SIZE		 (1ULL << 10)
 
 /*
  * request buffer is registered automatically to uring_cmd's io_uring
@@ -242,10 +275,37 @@
  */
 #define UBLK_F_AUTO_BUF_REG 	(1ULL << 11)
 
+/*
+ * Control command `UBLK_U_CMD_QUIESCE_DEV` is added for quiescing device,
+ * which state can be transitioned to `UBLK_S_DEV_QUIESCED` or
+ * `UBLK_S_DEV_FAIL_IO` finally, and it needs ublk server cooperation for
+ * handling `UBLK_IO_RES_ABORT` correctly.
+ *
+ * Typical use case is for supporting to upgrade ublk server application,
+ * meantime keep ublk block device persistent during the period.
+ *
+ * This feature is only available when UBLK_F_USER_RECOVERY is enabled.
+ *
+ * Note, this command returns -EBUSY in case that all IO commands are being
+ * handled by ublk server and not completed in specified time period which
+ * is passed from the control command parameter.
+ */
+#define UBLK_F_QUIESCE		(1ULL << 12)
+
+/*
+ * If this feature is set, ublk_drv supports each (qid,tag) pair having
+ * its own independent daemon task that is responsible for handling it.
+ * If it is not set, daemons are per-queue instead, so for two pairs
+ * (qid1,tag1) and (qid2,tag2), if qid1 == qid2, then the same task must
+ * be responsible for handling (qid1,tag1) and (qid2,tag2).
+ */
+#define UBLK_F_PER_IO_DAEMON (1ULL << 13)
+
 /* device state */
 #define UBLK_S_DEV_DEAD	0
 #define UBLK_S_DEV_LIVE	1
 #define UBLK_S_DEV_QUIESCED	2
+#define UBLK_S_DEV_FAIL_IO 	3
 
 /* shipped via sqe->cmd of io_uring command */
 struct ublksrv_ctrl_cmd {
@@ -350,15 +410,10 @@ struct ublksrv_io_desc {
 	/* op: bit 0-7, flags: bit 8-31 */
 	__u32		op_flags;
 
-	/* bindgen can't handle union well */
-#if 0
 	union {
 		__u32		nr_sectors;
 		__u32		nr_zones; /* for UBLK_IO_OP_REPORT_ZONES */
 	};
-#else
-		__u32		nr_sectors;
-#endif
 
 	/* start sector for this io */
 	__u64		start_sector;
@@ -443,7 +498,6 @@ struct ublksrv_io_cmd {
 	/* io result, it is valid for COMMIT* command only */
 	__s32	result;
 
-#if 0
 	union {
 		/*
 		 * userspace buffer address in ublksrv daemon process, valid for
@@ -459,9 +513,6 @@ struct ublksrv_io_cmd {
 		__u64	addr;
 		__u64	zone_append_lba;
 	};
-#else
-		__u64	addr;
-#endif
 };
 
 struct ublk_param_basic {
@@ -559,6 +610,8 @@ struct ublk_params {
 	struct ublk_param_discard	discard;
 	struct ublk_param_devt		devt;
 	struct ublk_param_zoned	zoned;
+	struct ublk_param_dma_align	dma;
+	struct ublk_param_segment	seg;
 };
 
 #endif

--- a/crates/smoo-test-harness/src/fixture.rs
+++ b/crates/smoo-test-harness/src/fixture.rs
@@ -83,41 +83,7 @@ impl GadgetFixture {
     /// on the dummy_hcd bus.
     pub async fn spawn(slot: Slot, opts: GadgetOpts, log_dir: &Path) -> Result<Self> {
         let configfs = GadgetConfigFs::create(&slot).context("configfs setup")?;
-
-        let bin = smoo_gadget_path()?;
-        let mut cmd = Command::new(&bin);
-        cmd.arg("--vendor-id")
-            .arg(format!("0x{:04x}", slot.vid))
-            .arg("--product-id")
-            .arg(format!("0x{:04x}", slot.pid))
-            .arg("--queue-count")
-            .arg(opts.queue_count.to_string())
-            .arg("--queue-depth")
-            .arg(opts.queue_depth.to_string())
-            .arg("--ffs-dir")
-            .arg(&configfs.ffs_mount_dir);
-        if let Some(max_io) = opts.max_io_bytes {
-            cmd.arg("--max-io").arg(max_io.to_string());
-        }
-        for arg in &opts.extra_args {
-            cmd.arg(arg);
-        }
-        apply_rust_log(&mut cmd, &opts.rust_log);
-
-        let child = ChildProcess::spawn("smoo-gadget", cmd, log_dir)
-            .await
-            .context("spawn smoo-gadget")?;
-
-        // Wait for the gadget to log readiness — fires from
-        // crates/smoo-gadget-app/src/lib.rs:193 after FunctionFS descriptors
-        // have been written and ep1-4 opened. The CLI's tracing-subscriber
-        // writes to stdout by default; use either stream so this works
-        // regardless of how a future caller configures it.
-        let re = Regex::new(r"smoo gadget initialized").unwrap();
-        child
-            .wait_for_either(&re, opts.readiness_timeout)
-            .await
-            .context("waiting for 'smoo gadget initialized'")?;
+        let child = spawn_gadget_child("smoo-gadget", &slot, &configfs, &opts, log_dir).await?;
 
         configfs.bind_udc().context("bind UDC")?;
 
@@ -127,6 +93,22 @@ impl GadgetFixture {
             observed_ublk_dev_ids: Mutex::new(Vec::new()),
             slot,
         })
+    }
+
+    pub async fn adopt_restart(&mut self, opts: GadgetOpts, log_dir: &Path) -> Result<ExitStatus> {
+        let successor = spawn_gadget_child(
+            "smoo-gadget-adopt",
+            &self.slot,
+            &self.configfs,
+            &opts,
+            log_dir,
+        )
+        .await
+        .context("spawn adopting smoo-gadget")?;
+        self.configfs.unbind_udc();
+        self.configfs.bind_udc().context("rebind UDC after adopt")?;
+        let old = std::mem::replace(&mut self.child, successor);
+        old.wait().await.context("wait for prior smoo-gadget")
     }
 
     /// Wait for the gadget to log a regex-matching line on either stream.
@@ -147,7 +129,8 @@ impl GadgetFixture {
     /// the gadget (one per export). Returns the dev_ids in the order they
     /// appeared. Each kernel-assigned id corresponds to `/dev/ublkb<id>`.
     pub async fn wait_for_ublk_dev_ids(&self, count: usize, timeout: Duration) -> Result<Vec<u32>> {
-        let id_re = Regex::new(r"start_dev completed.*dev_id=(\d+)").unwrap();
+        let id_re =
+            Regex::new(r"(?:start_dev completed|ublk target online).*dev_id=(\d+)").unwrap();
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             let mut ids: Vec<u32> = Vec::with_capacity(count);
@@ -207,6 +190,48 @@ impl GadgetFixture {
         drop(slot);
         Ok(status)
     }
+}
+
+async fn spawn_gadget_child(
+    name: &str,
+    slot: &Slot,
+    configfs: &GadgetConfigFs,
+    opts: &GadgetOpts,
+    log_dir: &Path,
+) -> Result<ChildProcess> {
+    let bin = smoo_gadget_path()?;
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--vendor-id")
+        .arg(format!("0x{:04x}", slot.vid))
+        .arg("--product-id")
+        .arg(format!("0x{:04x}", slot.pid))
+        .arg("--queue-count")
+        .arg(opts.queue_count.to_string())
+        .arg("--queue-depth")
+        .arg(opts.queue_depth.to_string())
+        .arg("--ffs-dir")
+        .arg(&configfs.ffs_mount_dir);
+    if let Some(max_io) = opts.max_io_bytes {
+        cmd.arg("--max-io").arg(max_io.to_string());
+    }
+    for arg in &opts.extra_args {
+        cmd.arg(arg);
+    }
+    apply_rust_log(&mut cmd, &opts.rust_log);
+
+    let child = ChildProcess::spawn(name, cmd, log_dir)
+        .await
+        .with_context(|| format!("spawn {name}"))?;
+
+    // Wait for descriptors/endpoints to be opened before the caller binds or
+    // relies on an existing UDC binding.
+    let re = Regex::new(r"smoo gadget initialized").unwrap();
+    child
+        .wait_for_either(&re, opts.readiness_timeout)
+        .await
+        .context("waiting for 'smoo gadget initialized'")?;
+
+    Ok(child)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/smoo-test-harness/src/process.rs
+++ b/crates/smoo-test-harness/src/process.rs
@@ -218,6 +218,13 @@ impl ChildProcess {
         Ok(status)
     }
 
+    pub async fn wait(mut self) -> Result<ExitStatus> {
+        let status = self.child.wait().await.context("waiting for child exit")?;
+        self.stdout_buf.close();
+        self.stderr_buf.close();
+        Ok(status)
+    }
+
     /// Try-wait without consuming. Returns Some(status) if the process has
     /// exited, None otherwise.
     pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {

--- a/crates/smoo-test-harness/src/scenario.rs
+++ b/crates/smoo-test-harness/src/scenario.rs
@@ -208,6 +208,7 @@ impl ScenarioBuilder {
             host: Some(host),
             host_sources,
             host_opts,
+            gadget_opts: self.gadget_opts,
             capture,
             exports: self.exports,
             queue_depth,
@@ -223,6 +224,7 @@ pub struct RunningScenario {
     pub host: Option<HostFixture>,
     host_sources: Vec<HostSourceSpec>,
     host_opts: HostOpts,
+    gadget_opts: GadgetOpts,
     pub capture: Option<CaptureSession>,
     pub exports: Vec<ExportSpec>,
     pub queue_depth: u32,
@@ -274,6 +276,23 @@ impl RunningScenario {
         let status = self.stop_host().await?;
         self.start_host().await?;
         Ok(status)
+    }
+
+    /// Spawn a successor gadget with `--adopt`-style options against the same
+    /// FunctionFS/configfs instance. The successor is responsible for signaling
+    /// and waiting for the current gadget owner via its CLI flags.
+    pub async fn adopt_restart_gadget(&mut self, successor_opts: GadgetOpts) -> Result<ExitStatus> {
+        let gadget = self.gadget.as_mut().context("gadget already shut down")?;
+        let status = gadget
+            .adopt_restart(successor_opts.clone(), self.artifacts.log_dir())
+            .await
+            .context("adopt-restart gadget")?;
+        self.gadget_opts = successor_opts;
+        Ok(status)
+    }
+
+    pub fn gadget_opts(&self) -> &GadgetOpts {
+        &self.gadget_opts
     }
 
     /// Shut down gadget, host, then capture. Keeping the host alive while the

--- a/crates/smoo-test-harness/tests/link_replay.rs
+++ b/crates/smoo-test-harness/tests/link_replay.rs
@@ -15,7 +15,7 @@ use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail, ensure};
 use hyper::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE};
@@ -124,6 +124,112 @@ async fn link_replay() -> Result<()> {
     // A replayed request is deliberately visible twice on the wire but has only
     // one final response, so strict request/response balance is not meaningful.
     result.assert(true, false).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires dummy_hcd/ublk/configfs; run via cargo xtask integration or vm-integration"]
+async fn user_recovery_handover_drains_inflight_io() -> Result<()> {
+    common::init_tracing();
+
+    let server = StallingHttpSource::start(BLOCK_SIZE, TOTAL_BLOCKS, SEED, READ_LBA)?;
+    let state_path = temp_state_path("user_recovery_handover_drains_inflight_io")?;
+    let state_arg = state_path.display().to_string();
+    let initial_opts = GadgetOpts {
+        queue_count: 1,
+        queue_depth: 4,
+        max_io_bytes: Some(BLOCK_SIZE as u64),
+        extra_args: vec!["--state-file".to_string(), state_arg.clone()],
+        readiness_timeout: Duration::from_secs(20),
+        ..GadgetOpts::default()
+    };
+
+    let mut sc = ScenarioBuilder::new("user_recovery_handover_drains_inflight_io")
+        .with_host_source(HostSourceSpec::Http(server.url()))
+        .with_block_size(BLOCK_SIZE)
+        .with_capture(false)
+        .with_gadget_opts(initial_opts.clone())
+        .start()
+        .await?;
+
+    let dev_id = sc
+        .gadget()
+        .wait_for_ublk_dev_id(Duration::from_secs(15))
+        .await?;
+    let dev_path = PathBuf::from(format!("/dev/ublkb{dev_id}"));
+    common::wait_for_block_device(&dev_path, Duration::from_secs(5)).await?;
+
+    server.arm();
+    let expected = expected_bytes(READ_LBA, 1).await?;
+    let initial_data_requests = server.target_request_count();
+    let mut read_task = tokio::spawn(read_device_bytes(
+        dev_path.clone(),
+        READ_LBA,
+        BLOCK_SIZE as usize,
+    ));
+    server
+        .wait_for_data_requests(initial_data_requests + 1, Duration::from_secs(15))
+        .await?;
+
+    let mut adopt_opts = initial_opts;
+    adopt_opts.readiness_timeout = Duration::from_secs(35);
+    adopt_opts.extra_args.push("--adopt".to_string());
+    adopt_opts
+        .extra_args
+        .extend(["--adopt-deadline".to_string(), "25s".to_string()]);
+    let mut adopt_fut = Box::pin(sc.adopt_restart_gadget(adopt_opts));
+
+    assert_device_read_pending(&mut read_task, Duration::from_secs(2)).await?;
+    match tokio::time::timeout(Duration::from_secs(2), adopt_fut.as_mut()).await {
+        Ok(Ok(status)) => bail!(
+            "adopt completed while HTTP read was still stalled; prior gadget status={status:?}"
+        ),
+        Ok(Err(err)) => bail!("adopt failed while HTTP read was still stalled: {err:#}"),
+        Err(_) => {}
+    }
+
+    server.release();
+    let actual = tokio::time::timeout(Duration::from_secs(15), &mut read_task)
+        .await
+        .context("timed out waiting for handover read to drain")?
+        .context("device read task panicked")??;
+    ensure_read_matches(&actual, &expected)?;
+    ensure!(
+        server.target_request_count() == initial_data_requests + 1,
+        "handover reissued the stalled read instead of draining it first"
+    );
+
+    let old_status = tokio::time::timeout(Duration::from_secs(20), adopt_fut.as_mut())
+        .await
+        .context("timed out waiting for adopting gadget to finish handover")??;
+    drop(adopt_fut);
+    ensure!(
+        old_status.success(),
+        "prior gadget exited unsuccessfully: {old_status:?}"
+    );
+    server.disarm();
+
+    let recovered_dev_id = sc
+        .gadget()
+        .wait_for_ublk_dev_id(Duration::from_secs(20))
+        .await?;
+    ensure!(
+        recovered_dev_id == dev_id,
+        "handover changed ublk dev_id: before={dev_id} after={recovered_dev_id}"
+    );
+    let after_lba = READ_LBA + 1;
+    let after_expected = expected_bytes(after_lba, 1).await?;
+    let after = tokio::time::timeout(
+        Duration::from_secs(30),
+        read_device_bytes(dev_path, after_lba, BLOCK_SIZE as usize),
+    )
+    .await
+    .context("timed out reading device after user-recovery handover")??;
+    ensure_read_matches(&after, &after_expected)?;
+
+    let result = sc.stop().await?;
+    result.assert(true, false).await?;
+    let _ = tokio::fs::remove_file(&state_path).await;
     Ok(())
 }
 
@@ -264,6 +370,10 @@ impl StallingHttpSource {
 
     fn arm(&self) {
         self.state.armed.store(true, Ordering::Release);
+    }
+
+    fn disarm(&self) {
+        self.state.armed.store(false, Ordering::Release);
     }
 
     fn target_request_count(&self) -> usize {
@@ -425,4 +535,12 @@ fn response(status: StatusCode, body: impl Into<Body>) -> Response<Body> {
         .status(status)
         .body(body.into())
         .expect("valid response")
+}
+
+fn temp_state_path(name: &str) -> Result<PathBuf> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX_EPOCH")?
+        .as_nanos();
+    Ok(std::env::temp_dir().join(format!("smoo-{name}-{}-{nanos}.json", std::process::id())))
 }

--- a/crates/smoo-test-harness/tests/user_recovery_handover.rs
+++ b/crates/smoo-test-harness/tests/user_recovery_handover.rs
@@ -1,0 +1,151 @@
+//! Regression: a successor smoo-gadget can adopt an existing ublk device via
+//! ublk user recovery while preserving the block device identity.
+
+mod common;
+
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail, ensure};
+use smoo_host_blocksources::random::RandomBlockSource;
+use smoo_host_core::BlockSource;
+use smoo_test_harness::ScenarioBuilder;
+use smoo_test_harness::fixture::{GadgetOpts, HostSourceSpec};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+const SEED: u64 = 0xAD0A7;
+const BLOCK_SIZE: u32 = 4096;
+const TOTAL_BLOCKS: u64 = 1024;
+const READ_LBA: u64 = 17;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires dummy_hcd/ublk/configfs; run via cargo xtask integration or vm-integration"]
+async fn user_recovery_handover() -> Result<()> {
+    common::init_tracing();
+
+    let state_path = temp_state_path("user_recovery_handover")?;
+    let state_arg = state_path.display().to_string();
+    let initial_opts = GadgetOpts {
+        queue_count: 1,
+        queue_depth: 4,
+        max_io_bytes: Some(BLOCK_SIZE as u64),
+        extra_args: vec!["--state-file".to_string(), state_arg.clone()],
+        readiness_timeout: Duration::from_secs(20),
+        ..GadgetOpts::default()
+    };
+
+    let mut sc = ScenarioBuilder::new("user_recovery_handover")
+        .with_host_source(HostSourceSpec::Random {
+            blocks: TOTAL_BLOCKS,
+            seed: SEED,
+        })
+        .with_block_size(BLOCK_SIZE)
+        .with_capture(false)
+        .with_gadget_opts(initial_opts.clone())
+        .start()
+        .await?;
+
+    let dev_id = sc
+        .gadget()
+        .wait_for_ublk_dev_id(Duration::from_secs(15))
+        .await?;
+    let dev_path = PathBuf::from(format!("/dev/ublkb{dev_id}"));
+    common::wait_for_block_device(&dev_path, Duration::from_secs(5)).await?;
+
+    let expected = expected_bytes(READ_LBA, 1).await?;
+    let before = read_device_bytes(&dev_path, READ_LBA, BLOCK_SIZE as usize).await?;
+    ensure_read_matches(&before, &expected)?;
+
+    let mut adopt_opts = initial_opts;
+    adopt_opts.readiness_timeout = Duration::from_secs(35);
+    adopt_opts.extra_args.push("--adopt".to_string());
+    adopt_opts
+        .extra_args
+        .extend(["--adopt-deadline".to_string(), "25s".to_string()]);
+    let old_status = sc.adopt_restart_gadget(adopt_opts).await?;
+    ensure!(
+        old_status.success(),
+        "prior gadget exited unsuccessfully: {old_status:?}"
+    );
+
+    let recovered_dev_id = sc
+        .gadget()
+        .wait_for_ublk_dev_id(Duration::from_secs(20))
+        .await?;
+    ensure!(
+        recovered_dev_id == dev_id,
+        "handover changed ublk dev_id: before={dev_id} after={recovered_dev_id}"
+    );
+
+    let after = tokio::time::timeout(
+        Duration::from_secs(30),
+        read_device_bytes(&dev_path, READ_LBA, BLOCK_SIZE as usize),
+    )
+    .await
+    .context("timed out reading device after user-recovery handover")??;
+    ensure_read_matches(&after, &expected)?;
+
+    let result = sc.stop().await?;
+    // This test already verifies bytes across handover above.
+    result.assert(true, false).await?;
+    let _ = tokio::fs::remove_file(&state_path).await;
+    Ok(())
+}
+
+fn temp_state_path(name: &str) -> Result<PathBuf> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX_EPOCH")?
+        .as_nanos();
+    Ok(std::env::temp_dir().join(format!("smoo-{name}-{}-{nanos}.json", std::process::id())))
+}
+
+async fn read_device_bytes(path: &Path, lba: u64, len: usize) -> Result<Vec<u8>> {
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .with_context(|| format!("open {}", path.display()))?;
+    let offset = lba
+        .checked_mul(BLOCK_SIZE as u64)
+        .context("read offset overflow")?;
+    file.seek(SeekFrom::Start(offset))
+        .await
+        .with_context(|| format!("seek {} +{offset}", path.display()))?;
+    let mut buf = vec![0u8; len];
+    file.read_exact(&mut buf)
+        .await
+        .with_context(|| format!("read {len} bytes from {}", path.display()))?;
+    Ok(buf)
+}
+
+async fn expected_bytes(lba: u64, blocks: u64) -> Result<Vec<u8>> {
+    let mut buf = vec![0u8; (blocks * BLOCK_SIZE as u64) as usize];
+    let source = RandomBlockSource::new(BLOCK_SIZE, TOTAL_BLOCKS, SEED)?;
+    source
+        .read_blocks(lba, &mut buf)
+        .await
+        .map_err(|err| anyhow::anyhow!("RandomBlockSource read_blocks: {err}"))?;
+    Ok(buf)
+}
+
+fn ensure_read_matches(actual: &[u8], expected: &[u8]) -> Result<()> {
+    ensure!(
+        actual.len() == expected.len(),
+        "read length mismatch: got {}, expected {}",
+        actual.len(),
+        expected.len()
+    );
+    if actual == expected {
+        return Ok(());
+    }
+    let diff = actual
+        .iter()
+        .zip(expected.iter())
+        .position(|(a, e)| a != e)
+        .unwrap_or_else(|| actual.len().min(expected.len()));
+    let actual_byte = actual.get(diff).copied();
+    let expected_byte = expected.get(diff).copied();
+    bail!(
+        "read returned wrong bytes: first diff at offset {diff} (actual={actual_byte:?} expected={expected_byte:?})"
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ const STABLE_HARNESS_TESTS: &[&str] = &[
     "pipelined_io",
     "max_io_read",
     "link_replay",
+    "user_recovery_handover",
 ];
 
 fn main() -> ExitCode {


### PR DESCRIPTION
Quiesce and release existing ublk devices on SIGHUP so a successor daemon can adopt them without completing in-flight I/O as failures. Add VM coverage for preserving the device identity across handover.